### PR TITLE
Google Places Reviews Stream

### DIFF
--- a/lib/stream/googleplaces_reviews.php
+++ b/lib/stream/googleplaces_reviews.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the YFeed package.
+ *
+ * @author (c) Yakamara Media GmbH & Co. KG
+ * @author thomas.blum@redaxo.org
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class rex_yfeed_stream_googleplaces_reviews extends rex_yfeed_stream_abstract
+{
+    public function getTypeName()
+    {
+        return rex_i18n::msg('yfeed_googleplaces_reviews');
+    }
+
+    public function getTypeParams()
+    {
+        return [
+            [
+                'label' => rex_i18n::msg('yfeed_googleplaces_placeid'),
+                'name' => 'place_id',
+                'type' => 'string',
+                'notice' => 'https://developers.google.com/places/web-service/details?hl=de'
+            ]
+        ];
+    }
+
+    public function fetch()
+    {
+
+	
+		$params = array(
+			'url' => 'https://maps.googleapis.com/maps/api/place/details/json?',
+            'key' => rex_config::get('yfeed', 'googleplaces_key'),
+            'placeid' => $this->typeParams['place_id']			
+		);
+		
+		$url = urldecode( array_shift( $params ) . http_build_query( $params, '', '&' ) );
+	
+		$response = false;
+		
+		$curl = curl_init();
+		curl_setopt($curl, CURLOPT_URL, $url);		
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		$response = curl_exec($curl);
+		curl_close($curl);
+		
+		if($response !== false) {
+ 			$data = json_decode($response,true);
+			$place = $data['result'];
+			dump($place);
+			foreach ($place['reviews'] as $review) {
+				$item = new rex_yfeed_item($this->streamId, $review['time']);
+				$item->setContentRaw($review['text']);
+				$item->setContent($review['text']);
+				$item->setTitle($review['rating']);
+
+				$item->setUrl($place['url']);
+				$item->setDate(new DateTime("@".$review['time']));
+
+				$item->setAuthor($review['author_name']);
+				$item->setLanguage($review['language']);
+				$item->setRaw(json_encode($review));
+
+				$item->setMedia($review['profile_photo_url']);
+
+				$this->updateCount($item);
+				$item->save();
+			} 
+		}
+
+    }
+}

--- a/lib/stream/googleplaces_reviews.php
+++ b/lib/stream/googleplaces_reviews.php
@@ -52,7 +52,7 @@ class rex_yfeed_stream_googleplaces_reviews extends rex_yfeed_stream_abstract
 		if($response !== false) {
  			$data = json_decode($response,true);
 			$place = $data['result'];
-			dump($place);
+
 			foreach ($place['reviews'] as $review) {
 				$item = new rex_yfeed_item($this->streamId, $review['time']);
 				$item->setContentRaw($review['text']);

--- a/package.yml
+++ b/package.yml
@@ -24,5 +24,7 @@ page:
                     title: 'translate:google'
                 instagram:
                     title: 'translate:instagram'
+                googleplaces:
+                    title: 'translate:googleplaces'
         faq:
             title: 'translate:faq'

--- a/pages/settings.googleplaces.php
+++ b/pages/settings.googleplaces.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the YFeed package.
+ *
+ * @author (c) Yakamara Media GmbH & Co. KG
+ * @author thomas.blum@redaxo.org
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$func = rex_request('func', 'string');
+
+if ($func == 'update') {
+    $this->setConfig(rex_post('settings', [
+        ['googleplaces_key', 'string'],
+    ]));
+
+    echo \rex_view::success($this->i18n('settings_saved'));
+}
+
+$content = '';
+
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="consumer-token">' . $this->i18n('googleplaces_key') . '</label>';
+$n['field'] = '<input class="form-control" type="text" id="consumer-token" name="settings[googleplaces_key]" value="' . htmlspecialchars($this->getConfig('googleplaces_key')) . '" />';
+$formElements[] = $n;
+
+$fragment = new \rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/form.php');
+
+$formElements = [];
+$n = [];
+$n['field'] = '<a class="btn btn-abort" href="' . \rex_url::currentBackendPage() . '">' . \rex_i18n::msg('form_abort') . '</a>';
+$formElements[] = $n;
+
+$n = [];
+$n['field'] = '<button class="btn btn-apply rex-form-aligned" type="submit" name="send" value="1"' . \rex::getAccesskey(\rex_i18n::msg('update'), 'apply') . '>' . \rex_i18n::msg('update') . '</button>';
+$formElements[] = $n;
+
+$fragment = new \rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$buttons = $fragment->parse('core/form/submit.php');
+
+$fragment = new \rex_fragment();
+$fragment->setVar('class', 'edit', false);
+$fragment->setVar('title', $this->i18n('googleplaces_settings'), false);
+$fragment->setVar('body', $content, false);
+$fragment->setVar('buttons', $buttons, false);
+$section = $fragment->parse('core/page/section.php');
+
+echo '
+    <form action="' . \rex_url::currentBackendPage() . '" method="post">
+        <input type="hidden" name="func" value="update" />
+        ' . $section . '
+    </form>
+';


### PR DESCRIPTION
Einstellungsseite für die API, Stream-Einstellungen und Zuordnung der
Antwort in entsprechende Datenbank-Felder

Todo: 
* Sprach-Platzhalter ersetzen (YTraduko?)
* Einträge standardmäßig offline schalten / Einstellungsmöglichkeit pro Stream bieten (um schlechte Bewertungen nicht automatisch zu aktivieren)
* Extra Rating-Feld in der DB anlegen, statt Titel-Feld für Rating zu benutzen (hier kenne ich den Update-Prozess nicht)
* Namespace überprüfen und ggf. abändern.

Hinweis: Es wird der Zeitstempel eines Reviews benutzt, da Google hier keine ID mitgibt und auch immer nur 5 Bewertungen nach eigenem Ermessen ausgibt, vermutlich die letzten 5.

Alle Infos zur API:
https://developers.google.com/places/web-service/details?hl=de