### PR TITLE
Fehlerbehebung für Album Bilder

### DIFF
--- a/lib/stream/facebook_feed.php
+++ b/lib/stream/facebook_feed.php
@@ -82,6 +82,17 @@ class rex_yfeed_stream_facebook_feed extends rex_yfeed_stream_abstract
 
             $attachments = $facebookItem->getField('attachments');
             if ($attachments) {
+                // fetch subattachments
+                unset($subAttachments);
+                foreach ($attachments as $attachment) {
+                    if ($attachment->getField('type') === 'album') {
+                        $subAttachments = $attachment->getField('subattachments');
+                        break;
+                    }
+                }
+
+                $attachments = isset($subAttachments) ? $subAttachments : $attachments;
+                
                 /** @var Facebook\GraphNodes\GraphNode $attachment */
                 foreach ($attachments as $attachment) {
                     if ('photo' !== $attachment->getField('type') || !$media = $attachment->getField('media')) {


### PR DESCRIPTION
Hallo,

wie ich festgestellt habe ist es aktuell nicht möglich Bilder aus einem Album aus dem Facebook feed zu bekommen.