### PR TITLE
Prüfung auf leere Facebook-Nachricht

### DIFF
--- a/lib/stream/facebook_feed.php
+++ b/lib/stream/facebook_feed.php
@@ -68,6 +68,11 @@ class rex_yfeed_stream_facebook_feed extends rex_yfeed_stream_abstract
 
         /** @var Facebook\GraphNodes\GraphNode $facebookItem */
         foreach ($items as $facebookItem) {
+            // ignore empty content
+            if (is_null($facebookItem->getField('message'))) {
+                continue;
+            }
+            
             $item = new rex_yfeed_item($this->streamId, $facebookItem->getField('id'));
             $item->setTitle($facebookItem->getField('story'));
             $item->setContentRaw($facebookItem->getField('message'));


### PR DESCRIPTION
Aktuell werden Posts mit leeren Nachrichten wurde in die Datenbank geschrieben, dadurch kommt es zur fehlerhaften Ausgabe. In diesen Nachrichten sind beispielsweise solche wie "hat sein Titelbild aktualisiert" o.ä.