### PR TITLE
Abruf des eigenen Streams via User 'self' & access_token

### DIFF
--- a/lib/stream/instagram_user.php
+++ b/lib/stream/instagram_user.php
@@ -40,7 +40,7 @@ class rex_feeds_stream_instagram_user extends rex_feeds_stream_instagram_abstrac
 
     protected function fetchItemsFromOfficialApi(Instagram $instagram)
     {
-        if (preg_match('/^\d+$/', $this->typeParams['user'])) {
+        if (preg_match('/^\d+$/', $this->typeParams['user']) || $this->typeParams['user'])=='self') {
             $user = $instagram->getUser($this->typeParams['user']);
         } else {
             $user = $instagram->getUserByUsername($this->typeParams['user']);


### PR DESCRIPTION
Ermöglicht den Abruf des eigenen Instagram-Streams via User 'self' und dem eigenen Access-Token.
https://www.instagram.com/developer/endpoints/users/