### PR TITLE
Cronjob stream blacklist

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -49,6 +49,8 @@ feeds_stream_status_saved = Der Status wurde gespeichert.
 
 
 feeds_cronjob = Feeds: Feeds abrufen
+feeds_blacklist_sources = Von Abruf ausschließen
+feeds_blacklist_sources_notice = Wenn ausgewählt, werden diese Quellen nicht gesichert.
 
 feeds_media_manager_effect = Datei: Aus Feeds einlesen (wenn *.feeds)
 


### PR DESCRIPTION
ermöglicht, Streams vom Cronjob auszuschließen, um bspw. unterschiedlich häufig Dienste abzurufen. closes #126