### PR TITLE
allow to catch all instagram posts

### DIFF
--- a/lib/stream/instagram_tag.php
+++ b/lib/stream/instagram_tag.php
@@ -32,7 +32,7 @@ class rex_feeds_stream_instagram_tag extends rex_feeds_stream_instagram_abstract
                 'label' => rex_i18n::msg('feeds_instagram_count'),
                 'name' => 'count',
                 'type' => 'select',
-                'options' => [5 => 5, 10 => 10, 15 => 15, 20 => 20, 30 => 30, 50 => 50, 75 => 75, 100 => 100],
+                'options' => [5 => 5, 10 => 10, 15 => 15, 20 => 20, 30 => 30, 50 => 50, 75 => 75, 100 => 100, 10000 => '♾'],
                 'default' => 10,
             ],
         ];

--- a/lib/stream/instagram_user.php
+++ b/lib/stream/instagram_user.php
@@ -32,7 +32,7 @@ class rex_feeds_stream_instagram_user extends rex_feeds_stream_instagram_abstrac
                 'label' => rex_i18n::msg('feeds_instagram_count'),
                 'name' => 'count',
                 'type' => 'select',
-                'options' => [5 => 5, 10 => 10, 15 => 15, 20 => 20, 30 => 30, 50 => 50, 75 => 75, 100 => 100],
+                'options' => [5 => 5, 10 => 10, 15 => 15, 20 => 20, 30 => 30, 50 => 50, 75 => 75, 100 => 100, 10000 => '♾'],
                 'default' => 10,
             ],
         ];


### PR DESCRIPTION
Es scheint nicht mehr möglich, wie in #103 beschrieben access_token ohne weiteres zu generieren. Auch die API scheint zugunsten der Instagram Display API und Instagram Graph API aufgegeben zu werden, wenn ich das richtig sehe. Deshalb gebe ich hier die Möglichkeit, 10000 Posts abzurufen - das sollte "alle" sehr nahe kommen ;)