### PR TITLE
$item->date sollte immer ein DateTime-Objekt sein

### DIFF
--- a/lib/item.php
+++ b/lib/item.php
@@ -160,9 +160,19 @@ class rex_feeds_item
 
     /**
      * Get date (format: Y-m-d H:i:s)
-     * @return DateTimeInterface Date
+     * @return string Date
+     * @deprecated use `getDateTime` instead
      */
     public function getDate()
+    {
+        return $this->date->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Get datetime object
+     * @return DateTimeInterface Date
+     */
+    public function getDateTime()
     {
         return $this->date;
     }

--- a/lib/item.php
+++ b/lib/item.php
@@ -100,7 +100,7 @@ class rex_feeds_item
             $rex_feeds_item->content = $sql->getValue('content');
             $rex_feeds_item->contentRaw = $sql->getValue('content_raw');
             $rex_feeds_item->url = $sql->getValue('url');
-            $rex_feeds_item->date = $sql->getValue('date');
+            $rex_feeds_item->date = new DateTimeImmutable($sql->getValue('date'));
             $rex_feeds_item->author = $sql->getValue('author');
             $rex_feeds_item->username = $sql->getValue('username');
             $rex_feeds_item->language = $sql->getValue('language');


### PR DESCRIPTION
Beim Auslesen eines Items aus der DB über `rex_feeds_item::get()` lieferte `$item->getDate()` ein String, laut phpdoc sollte es aber immer ein DateTimeInterface-Objekt sein.

Ich weiß bloß nicht, ist die get()-methode so schon released? Also kann es sein, dass manche bereits bei getDate() nun einen String erwarten?