### PR TITLE
Neue Methode $item->getMediaUrl()

### DIFF
--- a/lib/item.php
+++ b/lib/item.php
@@ -203,6 +203,23 @@ class rex_feeds_item
     }
 
     /**
+     * Get media manager url.
+     * @param string $type Media Manager type
+     */
+    public function getMediaUrl(string $type, bool $escape = true): ?string
+    {
+        if (!rex_addon::get('media_manager')->isAvailable()) {
+            throw new rex_exception(__CLASS__.'::getMediaUrl() can be used only when media_manager is activated.');
+        }
+
+        if (!$this->media) {
+            return null;
+        }
+
+        return rex_media_manager::getUrl($type, $this->primaryId.'.feeds', $this->date->getTimestamp(), $escape);
+    }
+
+    /**
      * Get raw data.
      * @return string JSON encoded raw data
      */


### PR DESCRIPTION
Aktuell, wenn man zu einem Item die Media-Manager-Url mit Cache-Buster haben möchte, muss man folgendes aufrufen:

```php
rex_media_manager::getUrl($mmType, $item->getId().'.feeds', $item->getDate()->getTimestamp())
```

Ich schlage vor, der Item-Klasse eine `getMediaUrl`-Methode zu spendieren, sodass man das selbe Ergebnis auch so bekommen kann:

```php
$item->getMediaUrl($mmType)
```

⚠️ Dieser PR ist abhängig von https://github.com/FriendsOfREDAXO/feeds/pull/149. Wenn der andere so nicht genommen werden kann, dann müsste man hier im PR noch was anpassen.