### PR TITLE
Whoops vermeiden - link und type sind deprecated

### DIFF
--- a/lib/stream/facebook_feed.php
+++ b/lib/stream/facebook_feed.php
@@ -62,7 +62,7 @@ class rex_feeds_stream_facebook_feed extends rex_feeds_stream_abstract
     {
         $fb = $this->getFacebook();
 
-        $fields = 'id,permalink_url,from,story,message,link,created_time,attachments,type';
+        $fields = 'id,permalink_url,from,story,message,created_time,attachments';
         $url = sprintf(
             '/%s/%s?locale=de&fields=%s&limit=%d',
             $this->typeParams['profile_id'],


### PR DESCRIPTION
Bei Abruf des Streams kam folgende Meldung:
`link field is deprecated for versions v3.3 and higher`