### PR TITLE
Ausgabe-Sortierung geändert

### DIFF
--- a/lib/stream_abstract.php
+++ b/lib/stream_abstract.php
@@ -44,7 +44,7 @@ abstract class rex_feeds_stream_abstract
 	{
 		$items = [];
 		$result = rex_sql::factory();
-		$result->setQuery('SELECT id FROM '. rex::getTablePrefix() .'feeds_item WHERE stream_id = '. $this->streamId .' ORDER BY updatedate DESC LIMIT 0, '. $number .';');
+		$result->setQuery('SELECT id FROM '. rex::getTablePrefix() .'feeds_item WHERE stream_id = '. $this->streamId .' ORDER BY date DESC LIMIT 0, '. $number .';');
 
 		for ($i = 0; $i < $result->getRows(); $i++) {
 			$item = rex_feeds_item::get($result->getValue('id'));

--- a/lib/stream_abstract.php
+++ b/lib/stream_abstract.php
@@ -40,11 +40,11 @@ abstract class rex_feeds_stream_abstract
 	 * @param int $number Number of items to be returned
 	 * @return \rex_feeds_item[] Array with item objects
 	 */
-	public function getPreloadedItems($number = 5)
+	public function getPreloadedItems($number = 5, $orderBy = 'updatedate')
 	{
 		$items = [];
 		$result = rex_sql::factory();
-		$result->setQuery('SELECT id FROM '. rex::getTablePrefix() .'feeds_item WHERE stream_id = '. $this->streamId .' ORDER BY date DESC LIMIT 0, '. $number .';');
+		$result->setQuery('SELECT id FROM '. rex::getTablePrefix() .'feeds_item WHERE stream_id = '. $this->streamId .' ORDER BY '.$orderBy.' DESC LIMIT 0, '. $number .';');
 
 		for ($i = 0; $i < $result->getRows(); $i++) {
 			$item = rex_feeds_item::get($result->getValue('id'));


### PR DESCRIPTION
damit nach "date" und nicht nach "updatedate" sortiert wird.

In der Beschreibung der Funktion getPreloadedItems() heißt es: "...orderd by date."
Es wird aber nach updatedate sortiert.