### PR TITLE
alt und title Attribut Werte escapen

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $media_manager_type = 'my_mediatype';
 $stream = rex_feeds_stream::get($stream_id);
 $items = $stream->getPreloadedItems(); // Standard gibt 5 Einträge zurück, sonst gewünschte Anzahl übergeben
     foreach($items as $item) {
-        print '<a href="'. $item->getUrl() .'" title="'. $stream->getTitle() .'">';
+        print '<a href="'. $item->getUrl() .'" title="'. rex_escape($stream->getTitle()) .'">';
         print '<img src="index.php?rex_media_type='. $media_manager_type .'&rex_media_file='. $item->getId() .'.feeds"  alt="'. rex_escape($item->getTitle()) .'" title="'. rex_escape($item->getTitle()) .'">'; 
         print '</a>';
     }
@@ -196,5 +196,4 @@ Alle Infos dazu unter: https://developer.vimeo.com/api/authentication
 ## Feeds und YForm
 
 Die Stream-Tabelle lässt sich im YForm-Tablemanager importieren. Dadurch ist es möglich eine eigene Oberfläche für die Redakteure bereitzustellen. 
-
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $stream = rex_feeds_stream::get($stream_id);
 $items = $stream->getPreloadedItems(); // Standard gibt 5 Einträge zurück, sonst gewünschte Anzahl übergeben
     foreach($items as $item) {
         print '<a href="'. $item->getUrl() .'" title="'. $stream->getTitle() .'">';
-        print '<img src="index.php?rex_media_type='. $media_manager_type .'&rex_media_file='. $item->getId() .'.feeds"  alt="'. $item->getTitle() .'" title="'. $item->getTitle() .'">'; 
+        print '<img src="index.php?rex_media_type='. $media_manager_type .'&rex_media_file='. $item->getId() .'.feeds"  alt="'. rex_escape($item->getTitle()) .'" title="'. rex_escape($item->getTitle()) .'">'; 
         print '</a>';
     }
 ```


### PR DESCRIPTION
Ist mir gerade um die Ohren geflogen, weil Kunde Text mit `"` bei Instagram eingegeben hat.