### PR TITLE
Änderung default orderBy zu date

### DIFF
--- a/lib/stream_abstract.php
+++ b/lib/stream_abstract.php
@@ -40,7 +40,7 @@ abstract class rex_feeds_stream_abstract
 	 * @param int $number Number of items to be returned
 	 * @return \rex_feeds_item[] Array with item objects
 	 */
-	public function getPreloadedItems($number = 5, $orderBy = 'updatedate')
+	public function getPreloadedItems($number = 5, $orderBy = 'date')
 	{
 		$items = [];
 		$result = rex_sql::factory();


### PR DESCRIPTION
Beim initialen Abruf stimmt sonst nicht die Reihenfolge, vor allem wenn eine Collection mit rss.app geladen wurde.
Beim Abruf kann man immer noch umstellen auf updatedate. 
Eigentlich möchte man aber die korrekte chronologische Reihenfolge und nicht das Update-Datum für die Sortierung. 