### PR TITLE
Anpassung für PHP 8.1

### DIFF
--- a/pages/settings.facebook.php
+++ b/pages/settings.facebook.php
@@ -26,18 +26,18 @@ $content = '';
 $formElements = [];
 $n = [];
 $n['label'] = '<label for="facebook-app-title">' . $addon->i18n('facebook_app_title') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="facebook-app-title" name="settings[facebook_app_title]" value="' . htmlspecialchars($addon->getConfig('facebook_app_title')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="facebook-app-title" name="settings[facebook_app_title]" value="' . htmlspecialchars($addon->getConfig('facebook_app_title') ?? '') . '" />';
 $n['note'] = $addon->i18n('facebook_app_title_note');
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="facebook-app-id">' . $addon->i18n('facebook_app_id') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="facebook-app-id" name="settings[facebook_app_id]" value="' . htmlspecialchars($addon->getConfig('facebook_app_id')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="facebook-app-id" name="settings[facebook_app_id]" value="' . htmlspecialchars($addon->getConfig('facebook_app_id') ?? '') . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="facebook-app-secret">' . $addon->i18n('facebook_app_secret') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="facebook-app-secret" name="settings[facebook_app_secret]" value="' . htmlspecialchars($addon->getConfig('facebook_app_secret')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="facebook-app-secret" name="settings[facebook_app_secret]" value="' . htmlspecialchars($addon->getConfig('facebook_app_secret') ?? '') . '" />';
 $formElements[] = $n;
 
 $fragment = new \rex_fragment();

--- a/pages/settings.instagram.php
+++ b/pages/settings.instagram.php
@@ -24,7 +24,7 @@ $content = '';
 $formElements = [];
 $n = [];
 $n['label'] = '<label for="consumer-token">' . $this->i18n('instagram_access_token') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="consumer-token" name="settings[instagram_access_token]" value="' . htmlspecialchars($this->getConfig('instagram_access_token')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="consumer-token" name="settings[instagram_access_token]" value="' . htmlspecialchars($this->getConfig('instagram_access_token') ?? '') . '" />';
 $formElements[] = $n;
 
 $fragment = new \rex_fragment();

--- a/pages/settings.twitter.php
+++ b/pages/settings.twitter.php
@@ -27,22 +27,22 @@ $content = '';
 $formElements = [];
 $n = [];
 $n['label'] = '<label for="consumer-token">' . $this->i18n('twitter_consumer_key') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="consumer-token" name="settings[twitter_consumer_key]" value="' . htmlspecialchars($this->getConfig('twitter_consumer_key')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="consumer-token" name="settings[twitter_consumer_key]" value="' . htmlspecialchars($this->getConfig('twitter_consumer_key') ?? '') . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="consumer-secret">' . $this->i18n('twitter_consumer_secret') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="consumer-secret" name="settings[twitter_consumer_secret]" value="' . htmlspecialchars($this->getConfig('twitter_consumer_secret')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="consumer-secret" name="settings[twitter_consumer_secret]" value="' . htmlspecialchars($this->getConfig('twitter_consumer_secret') ?? '') . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="oauth-token">' . $this->i18n('twitter_oauth_token') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="oauth-token" name="settings[twitter_oauth_token]" value="' . htmlspecialchars($this->getConfig('twitter_oauth_token')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="oauth-token" name="settings[twitter_oauth_token]" value="' . htmlspecialchars($this->getConfig('twitter_oauth_token') ?? '') . '" />';
 $formElements[] = $n;
 
 $n = [];
 $n['label'] = '<label for="oauth-token-secret">' . $this->i18n('twitter_oauth_token_secret') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="oauth-token-secret" name="settings[twitter_oauth_token_secret]" value="' . htmlspecialchars($this->getConfig('twitter_oauth_token_secret')) . '" />';
+$n['field'] = '<input class="form-control" type="text" id="oauth-token-secret" name="settings[twitter_oauth_token_secret]" value="' . htmlspecialchars($this->getConfig('twitter_oauth_token_secret') ?? '') . '" />';
 $formElements[] = $n;
 
 $fragment = new \rex_fragment();


### PR DESCRIPTION
htmlspecialchars darf kein "null" übergeben werden