### PR TITLE
Fix Title-Feld wurde nicht übernommen

### DIFF
--- a/lib/stream/rss.php
+++ b/lib/stream/rss.php
@@ -43,7 +43,7 @@ class rex_feeds_stream_rss extends rex_feeds_stream_abstract
         /** @var Item $rssItem */
         foreach ($result->getFeed()  as $rssItem) {
             $item = new rex_feeds_item($this->streamId, $rssItem->getPublicId());
-            $item->setTitle($item->getTitle());
+            $item->setTitle($rssItem->getTitle());
             $item->setContentRaw($rssItem->getContent());
             $item->setContent(strip_tags($rssItem->getContent()));
             $item->setUrl($rssItem->getLink());

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: feeds
-version: '4.0.5'
+version: '4.0.6'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/feeds
 


### PR DESCRIPTION
Das Feld "title" wurde nicht aus dem Feed in die feed_item Tabelle geschrieben.