### PR TITLE
mediainfo fix

### DIFF
--- a/lib/item.php
+++ b/lib/item.php
@@ -206,10 +206,11 @@ class rex_feeds_item
     /**
      * Get media manager url
      * @param string $type Media Manager type
+     * @param bool $useOriginalFilename Whether to use the original filename instead of ID.feeds
      * @param bool $escape Whether to escape the URL
      * @return string|null Media Manager URL
      */
-    public function getMediaManagerUrl($type, $escape = true)
+    public function getMediaManagerUrl($type, $useOriginalFilename = false, $escape = true)
     {
         if (!rex_addon::get('media_manager')->isAvailable()) {
             throw new rex_exception(__CLASS__ . '::getMediaManagerUrl() can be used only when media_manager is activated.');
@@ -219,7 +220,16 @@ class rex_feeds_item
             return null;
         }
 
-        return rex_media_manager::getUrl($type, $this->primaryId . '.feeds', $this->date ? $this->date->getTimestamp() : null, $escape);
+        $filename = $useOriginalFilename && $this->media_filename
+            ? $this->media_filename
+            : $this->primaryId . '.feeds';
+
+        return rex_media_manager::getUrl(
+            $type,
+            $filename,
+            $this->date ? $this->date->getTimestamp() : null,
+            $escape
+        );
     }
 
     /**
@@ -230,33 +240,33 @@ class rex_feeds_item
      */
     public function getMediaInfo($type)
     {
-    if (!rex_addon::get('media_manager')->isAvailable()) {
-        throw new rex_exception(__CLASS__ . '::getMediaInfo() can be used only when media_manager is activated.');
-    }
+        if (!rex_addon::get('media_manager')->isAvailable()) {
+            throw new rex_exception(__CLASS__ . '::getMediaInfo() can be used only when media_manager is activated.');
+        }
 
-    if (!$this->primaryId) {
-        return null;
-    }
+        if (!$this->primaryId) {
+            return null;
+        }
 
-    // Get the actual media filename from the database
-    if (!$this->media_filename) {
-        return null;
-    }
+        // Get the actual media filename from the database
+        if (!$this->media_filename) {
+            return null;
+        }
 
-    // Use the actual media filename instead of {id}.feeds
-    $media = rex_media_manager::create($type, $this->media_filename)->getMedia();
+        // Use the actual media filename instead of {id}.feeds
+        $media = rex_media_manager::create($type, $this->media_filename)->getMedia();
 
-    if (!$media) {
-        return null;
-    }
+        if (!$media) {
+            return null;
+        }
 
-    return [
-        'format' => pathinfo($this->media_filename, PATHINFO_EXTENSION),
-        'width' => $media->getWidth(),
-        'height' => $media->getHeight(),
-        'filename' => $this->media_filename,
-        'type' => $type
-    ];
+        return [
+            'format' => pathinfo($this->media_filename, PATHINFO_EXTENSION),
+            'width' => $media->getWidth(),
+            'height' => $media->getHeight(),
+            'filename' => $this->media_filename,
+            'type' => $type
+        ];
     }
 
     /**

--- a/lib/item.php
+++ b/lib/item.php
@@ -230,28 +230,33 @@ class rex_feeds_item
      */
     public function getMediaInfo($type)
     {
-        if (!rex_addon::get('media_manager')->isAvailable()) {
-            throw new rex_exception(__CLASS__ . '::getMediaInfo() can be used only when media_manager is activated.');
-        }
+    if (!rex_addon::get('media_manager')->isAvailable()) {
+        throw new rex_exception(__CLASS__ . '::getMediaInfo() can be used only when media_manager is activated.');
+    }
 
-        if (!$this->primaryId) {
-            return null;
-        }
+    if (!$this->primaryId) {
+        return null;
+    }
 
-        $file = $this->primaryId . '.feeds';
-        $media = rex_media_manager::create($type, $file)->getMedia();
+    // Get the actual media filename from the database
+    if (!$this->media_filename) {
+        return null;
+    }
 
-        if (!$media) {
-            return null;
-        }
+    // Use the actual media filename instead of {id}.feeds
+    $media = rex_media_manager::create($type, $this->media_filename)->getMedia();
 
-        return [
-            'format' => $media->getFormat(),
-            'width' => $media->getWidth(),
-            'height' => $media->getHeight(),
-            'filename' => $file,
-            'type' => $type
-        ];
+    if (!$media) {
+        return null;
+    }
+
+    return [
+        'format' => pathinfo($this->media_filename, PATHINFO_EXTENSION),
+        'width' => $media->getWidth(),
+        'height' => $media->getHeight(),
+        'filename' => $this->media_filename,
+        'type' => $type
+    ];
     }
 
     /**

--- a/lib/media_manager_effect.php
+++ b/lib/media_manager_effect.php
@@ -9,24 +9,36 @@ class rex_effect_feeds extends rex_effect_abstract
         }
 
         // Check if this is a feeds file and extract the ID
-        if (!preg_match('/^(\d+)\.feeds$/', $filename, $match)) {
-            return;
-        }
-        $id = $match[1];
-
-        // Get the item from database
-        $sql = rex_sql::factory()
-            ->setTable(rex_feeds_item::table())
-            ->setWhere(['id' => $id, 'status' => 1])
-            ->select('media_filename');
-
-        if (!$sql->getRows()) {
-            return;
-        }
-        
-        $mediaFilename = $sql->getValue('media_filename');
-        if (!$mediaFilename) {
-            return;
+        if (preg_match('/^(\d+)\.feeds$/', $filename, $match)) {
+            // Handle ID-based format
+            $id = $match[1];
+            
+            // Get the item from database
+            $sql = rex_sql::factory()
+                ->setTable(rex_feeds_item::table())
+                ->setWhere(['id' => $id, 'status' => 1])
+                ->select('media_filename');
+                
+            if (!$sql->getRows()) {
+                return;
+            }
+            
+            $mediaFilename = $sql->getValue('media_filename');
+            if (!$mediaFilename) {
+                return;
+            }
+        } else {
+            // Handle direct filename format
+            $sql = rex_sql::factory()
+                ->setTable(rex_feeds_item::table())
+                ->setWhere(['media_filename' => $filename, 'status' => 1])
+                ->select('media_filename');
+                
+            if (!$sql->getRows()) {
+                return;
+            }
+            
+            $mediaFilename = $filename;
         }
 
         // Set the media path to the feeds media file


### PR DESCRIPTION
fixed https://github.com/FriendsOfREDAXO/feeds/issues/221

Now returns: 

[▼
    "format" => "jpeg"
    "width" => 60
    "height" => 32
    "filename" => "147.feeds"
    "type" => "feeds_thumb"
]


Neu: 

// Ursprüngliche ID-basierte URL (funktioniert weiterhin)
$url = $item->getMediaManagerUrl('feeds_thumb');
// Ergebnis: /media/feeds_thumb/146.feeds

// Neu: Verwendung des Original-Dateinamens
$url = $item->getMediaManagerUrl('feeds_thumb', true);
// Ergebnis: /media/feeds_thumb/original-bild.jpg