### PR TITLE
Namespace-Umstellung nachbearbeitet

### DIFF
--- a/lib/Cronjob.php
+++ b/lib/Cronjob.php
@@ -11,26 +11,34 @@
 
 namespace FriendsOfRedaxo\Feeds;
 
-class Cronjob extends \rex_cronjob
+use Exception;
+use rex_addon;
+use rex_cronjob;
+use rex_i18n;
+use Throwable;
+
+use function count;
+use function in_array;
+use function sprintf;
+
+class Cronjob extends rex_cronjob
 {
     public function execute()
     {
         $streams = [];
         $streamlist = [];
 
-        if ($this->getParam('stream_list') && $this->getParam('stream_list') !== '') {
+        if ($this->getParam('stream_list') && '' !== $this->getParam('stream_list')) {
             $streamlist = explode('|', $this->getParam('stream_list'));
         }
 
         foreach (Stream::getAllActivated() as $stream) {
-
-            if (in_array($stream->getStreamId(),  $streamlist) || !$this->getParam('stream_list') || $this->getParam('stream_list') === '') {
+            if (in_array($stream->getStreamId(), $streamlist) || !$this->getParam('stream_list') || '' === $this->getParam('stream_list')) {
                 $streams[] = $stream;
             } else {
                 continue;
             }
         }
-
 
         $errors = [];
         $countAdded = 0;
@@ -39,9 +47,9 @@ class Cronjob extends \rex_cronjob
         foreach ($streams as $stream) {
             try {
                 $stream->fetch();
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $errors[] = $stream->getTitle();
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $errors[] = $stream->getTitle();
             }
             $countAdded += $stream->getAddedCount();
@@ -54,7 +62,7 @@ class Cronjob extends \rex_cronjob
             $errors ? ' (' . implode(', ', $errors) . ')' : '',
             $countAdded,
             $countUpdated,
-            $countNotUpdatedChangedByUser
+            $countNotUpdatedChangedByUser,
         ));
         return empty($errors);
     }
@@ -63,6 +71,7 @@ class Cronjob extends \rex_cronjob
     {
         return rex_addon::get('feeds')->i18n('feeds_cronjob');
     }
+
     public function getParamFields()
     {
         $options = [];

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -11,10 +11,12 @@
 
 namespace FriendsOfRedaxo\Feeds;
 
+use rex_socket;
+
 class Helper
 {
     /**
-     * Generates the data uri for a remote resource
+     * Generates the data uri for a remote resource.
      *
      * @param string $url
      *
@@ -22,14 +24,14 @@ class Helper
      */
     public static function getDataUri($url)
     {
-        $response = \rex_socket::factoryUrl($url)->doGet();
+        $response = rex_socket::factoryUrl($url)->doGet();
         $mimeType = $response->getHeader('content-type');
-        $uri = 'data:'.$mimeType;
+        $uri = 'data:' . $mimeType;
 
-        if (0 === strpos($mimeType, 'text/')) {
-            $uri .= ','.rawurlencode($response->getBody());
+        if (str_starts_with($mimeType, 'text/')) {
+            $uri .= ',' . rawurlencode($response->getBody());
         } else {
-            $uri .= ';base64,'.base64_encode($response->getBody());
+            $uri .= ';base64,' . base64_encode($response->getBody());
         }
 
         return $uri;

--- a/lib/MediaManagerEffect.php
+++ b/lib/MediaManagerEffect.php
@@ -11,7 +11,12 @@
 
 namespace FriendsOfRedaxo\Feeds;
 
-class MediaManagerEffect extends \rex_effect_abstract
+use rex_effect_abstract;
+use rex_i18n;
+use rex_path;
+use rex_sql;
+
+class MediaManagerEffect extends rex_effect_abstract
 {
     public function execute()
     {
@@ -24,42 +29,42 @@ class MediaManagerEffect extends \rex_effect_abstract
         if (preg_match('/^(\d+)\.feeds$/', $filename, $match)) {
             // Handle ID-based format
             $id = $match[1];
-            
+
             // Get the item from database
-            $sql = \rex_sql::factory()
+            $sql = rex_sql::factory()
                 ->setTable(Item::table())
                 ->setWhere(['id' => $id, 'status' => 1])
                 ->select('media_filename');
-                
+
             if (!$sql->getRows()) {
                 return;
             }
-            
+
             $mediaFilename = $sql->getValue('media_filename');
             if (!$mediaFilename) {
                 return;
             }
         } else {
             // Handle direct filename format
-            $sql = \rex_sql::factory()
+            $sql = rex_sql::factory()
                 ->setTable(Item::table())
                 ->setWhere(['media_filename' => $filename, 'status' => 1])
                 ->select('media_filename');
-                
+
             if (!$sql->getRows()) {
                 return;
             }
-            
+
             $mediaFilename = $filename;
         }
 
         // Set the media path to the feeds media file
-        $mediaPath = \rex_path::addonData('feeds', 'media/' . $mediaFilename);
+        $mediaPath = rex_path::addonData('feeds', 'media/' . $mediaFilename);
         $this->media->setMediaPath($mediaPath);
     }
 
     public function getName()
     {
-        return \rex_i18n::msg('feeds_media_manager_effect');
+        return rex_i18n::msg('feeds_media_manager_effect');
     }
 }

--- a/lib/Stream.php
+++ b/lib/Stream.php
@@ -39,7 +39,7 @@ class Stream
     }
 
     /**
-     * @return array<AbstractStream>
+     * @return AbstractStream[]
      */
     public static function getAllActivated()
     {

--- a/lib/Stream.php
+++ b/lib/Stream.php
@@ -11,6 +11,11 @@
 
 namespace FriendsOfRedaxo\Feeds;
 
+use FriendsOfRedaxo\Feeds\Stream\AbstractStream;
+use rex;
+use rex_exception;
+use rex_sql;
+
 class Stream
 {
     private static $streams = [];
@@ -18,7 +23,7 @@ class Stream
     /**
      * @param int $id
      *
-     * @return \FriendsOfRedaxo\Feeds\Stream\AbstractStream|null
+     * @return AbstractStream|null
      */
     public static function get($id)
     {
@@ -34,7 +39,7 @@ class Stream
     }
 
     /**
-     * @return \FriendsOfRedaxo\Feeds\Stream\AbstractStream[]
+     * @return array<AbstractStream>
      */
     public static function getAllActivated()
     {
@@ -45,10 +50,8 @@ class Stream
     }
 
     /**
-     * @param array $data
-     *
-     * @return \FriendsOfRedaxo\Feeds\Stream\AbstractStream
      * @throws rex_exception
+     * @return AbstractStream
      */
     public static function create(array $data)
     {
@@ -62,7 +65,7 @@ class Stream
             throw new rex_exception('The feeds stream type is not supported');
         }
 
-        /** @var \FriendsOfRedaxo\Feeds\Stream\AbstractStream $stream */
+        /** @var AbstractStream $stream */
         $stream = new $streams[$type]();
         if (isset($data['type_params'])) {
             $stream->setTypeParams(json_decode($data['type_params'], true));
@@ -88,11 +91,11 @@ class Stream
             return self::$streams;
         }
 
-        $files = glob(__DIR__ . '/Stream/' . '*.php');
+        $files = glob(__DIR__ . '/Stream/*.php');
         if ($files) {
             foreach ($files as $file) {
                 $filename = basename($file, '.php');
-                if ($filename !== 'AbstractStream') {
+                if ('AbstractStream' !== $filename) {
                     $type = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $filename));
                     self::$streams[$type] = 'FriendsOfRedaxo\\Feeds\\Stream\\' . $filename;
                 }

--- a/lib/Stream/AbstractStream.php
+++ b/lib/Stream/AbstractStream.php
@@ -12,6 +12,10 @@
 namespace FriendsOfRedaxo\Feeds\Stream;
 
 use FriendsOfRedaxo\Feeds\Item;
+use rex;
+use rex_extension;
+use rex_extension_point;
+use rex_sql;
 
 abstract class AbstractStream
 {
@@ -39,27 +43,27 @@ abstract class AbstractStream
         $this->title = $value;
     }
 
-	/**
-	 * Get in Feeds database stored items belonging to this stream orderd by date.
-	 * @param int $number Number of items to be returned
-	 * @return Item[] Array with item objects
-	 */
-	public function getPreloadedItems($number = 5, $orderBy = 'date')
-	{
-		$items = [];
-		$result = \rex_sql::factory();
-		$result->setQuery('SELECT id FROM '. rex::getTablePrefix() .'feeds_item WHERE status = 1 AND stream_id = '. $this->streamId .' ORDER BY '.$orderBy.' DESC LIMIT 0, '. $number .';');
+    /**
+     * Get in Feeds database stored items belonging to this stream orderd by date.
+     * @param int $number Number of items to be returned
+     * @return array<Item> Array with item objects
+     */
+    public function getPreloadedItems($number = 5, $orderBy = 'date')
+    {
+        $items = [];
+        $result = rex_sql::factory();
+        $result->setQuery('SELECT id FROM ' . rex::getTablePrefix() . 'feeds_item WHERE status = 1 AND stream_id = ' . $this->streamId . ' ORDER BY ' . $orderBy . ' DESC LIMIT 0, ' . $number . ';');
 
-		for ($i = 0; $i < $result->getRows(); $i++) {
-			$item = Item::get($result->getValue('id'));
-			if($item != null) {
-				$items[] = $item;
-			}
-			$result->next();
-		}
-		return $items;
-	}
-    
+        for ($i = 0; $i < $result->getRows(); ++$i) {
+            $item = Item::get($result->getValue('id'));
+            if (null != $item) {
+                $items[] = $item;
+            }
+            $result->next();
+        }
+        return $items;
+    }
+
     public function getStreamId()
     {
         return $this->streamId;
@@ -80,13 +84,13 @@ abstract class AbstractStream
         $this->lastModified = $value;
     }
 
-
-    protected function registerExtensionPoint($stream_id) {
-        return \rex_extension::registerPoint(new \rex_extension_point(
-        'FEEDS_STREAM_FETCHED',
-        null, ['stream_id' => $stream_id]
+    protected function registerExtensionPoint($stream_id)
+    {
+        return rex_extension::registerPoint(new rex_extension_point(
+            'FEEDS_STREAM_FETCHED',
+            null, ['stream_id' => $stream_id],
         ));
-    }   
+    }
 
     public function getAddedCount()
     {

--- a/lib/Stream/AbstractStream.php
+++ b/lib/Stream/AbstractStream.php
@@ -46,7 +46,7 @@ abstract class AbstractStream
     /**
      * Get in Feeds database stored items belonging to this stream orderd by date.
      * @param int $number Number of items to be returned
-     * @return array<Item> Array with item objects
+     * @return Item[] Array with item objects
      */
     public function getPreloadedItems($number = 5, $orderBy = 'date')
     {

--- a/lib/Stream/Ics.php
+++ b/lib/Stream/Ics.php
@@ -5,106 +5,109 @@
  *
  * @author FOR
  * @author cukabeka
- *
  */
 
 namespace FriendsOfRedaxo\Feeds\Stream;
 
+use DateTime;
+use Exception;
 use FriendsOfRedaxo\Feeds\Item;
+use rex_i18n;
+use rex_view;
 
 class Ics extends AbstractStream
 {
     public function getTypeName()
     {
-        return \rex_i18n::msg('feeds_ical_calendar');
+        return rex_i18n::msg('feeds_ical_calendar');
     }
 
     public function getTypeParams()
     {
         return [
             [
-                'label' => \rex_i18n::msg('feeds_ical_url'),
+                'label' => rex_i18n::msg('feeds_ical_url'),
                 'name' => 'url',
-                'lang' => \rex_i18n::msg('feeds_ical_lang'),
+                'lang' => rex_i18n::msg('feeds_ical_lang'),
                 'type' => 'string',
             ],
         ];
     }
 
- public function fetch()
-{
-    $url = $this->typeParams['url'];
+    public function fetch()
+    {
+        $url = $this->typeParams['url'];
 
-    try {
-        $icsData = file_get_contents($url);
-        if ($icsData === false) {
-            $errorMessage = \rex_i18n::msg('feeds_error_fetch_ics') ?: 'Error fetching ICS data.';
-            throw new \Exception($errorMessage);
+        try {
+            $icsData = file_get_contents($url);
+            if (false === $icsData) {
+                $errorMessage = rex_i18n::msg('feeds_error_fetch_ics') ?: 'Error fetching ICS data.';
+                throw new Exception($errorMessage);
+            }
+
+            $events = $this->parseIcs($icsData);
+            foreach ($events as $event) {
+                $item = new Item($this->streamId, $event['UID']);
+                $item->setTitle($event['SUMMARY']);
+                $item->setContent($event['DESCRIPTION'] ?? '');
+                $item->setUrl($event['URL'] ?? '');
+                $item->setDate(new DateTime($event['DTSTART']));
+                $item->setRaw((bool) ($event['DESCRIPTION'] ?? null));
+
+                // Spracheinstellung, hier als Beispiel fest auf "de" gesetzt, evtl in die
+                // Da ICS-Dateien normalerweise keine Sprachinformationen enthalten, müssen Sie entscheiden, wie Sie die Sprache bestimmen möchten
+                $item->setLanguage($this->typeParams['lang']);
+
+                $this->updateCount($item);
+                $item->save();
+            }
+        } catch (Exception $e) {
+            echo rex_view::error($e->getMessage());
         }
-
-        $events = $this->parseIcs($icsData);
-        foreach ($events as $event) {
-            $item = new Item($this->streamId, $event['UID']);
-            $item->setTitle($event['SUMMARY']);
-            $item->setContent($event['DESCRIPTION'] ?? '');
-            $item->setUrl($event['URL'] ?? '');
-            $item->setDate(new DateTime($event['DTSTART']));
-            $item->setRaw((bool) ($event['DESCRIPTION'] ?? null));
-
-            // Spracheinstellung, hier als Beispiel fest auf "de" gesetzt, evtl in die
-            // Da ICS-Dateien normalerweise keine Sprachinformationen enthalten, müssen Sie entscheiden, wie Sie die Sprache bestimmen möchten
-            $item->setLanguage($this->typeParams['lang']);
-
-            $this->updateCount($item);
-            $item->save();
-        }
-    } catch (\Exception $e) {
-        echo \rex_view::error($e->getMessage());
     }
-}
 
-private function parseIcs($icsData)
-{
-    $lines = explode("\n", $icsData);
-    $events = [];
-    $event = [];
-    $currentKey = '';
+    private function parseIcs($icsData)
+    {
+        $lines = explode("\n", $icsData);
+        $events = [];
+        $event = [];
+        $currentKey = '';
 
-    foreach ($lines as $line) {
-        if (str_starts_with($line, 'BEGIN:VEVENT')) {
-            $event = []; // Neues Event starten
-        } elseif (str_starts_with($line, 'END:VEVENT')) {
-            $events[] = $event; // Event hinzufügen
-        } else {
-            if ($line[0] === " " || $line[0] === "\t") { // Fortsetzung einer Zeile
-                $event[$currentKey] .= ltrim($line);
+        foreach ($lines as $line) {
+            if (str_starts_with($line, 'BEGIN:VEVENT')) {
+                $event = []; // Neues Event starten
+            } elseif (str_starts_with($line, 'END:VEVENT')) {
+                $events[] = $event; // Event hinzufügen
             } else {
-                list($key, $value) = explode(':', $line, 2) + [null, null];
-                if ($key && $value) {
-                    // Behandlung von Eigenschaften mit Parametern (z.B. DTSTART;TZID=Europe/Berlin)
-                    if (strpos($key, ';') !== false) {
-                        list($key, $parameter) = explode(';', $key, 2);
-                        // Optional: Parameterverarbeitung hier hinzufügen, falls benötigt
+                if (' ' === $line[0] || "\t" === $line[0]) { // Fortsetzung einer Zeile
+                    $event[$currentKey] .= ltrim($line);
+                } else {
+                    [$key, $value] = explode(':', $line, 2) + [null, null];
+                    if ($key && $value) {
+                        // Behandlung von Eigenschaften mit Parametern (z.B. DTSTART;TZID=Europe/Berlin)
+                        if (str_contains($key, ';')) {
+                            [$key, $parameter] = explode(';', $key, 2);
+                            // Optional: Parameterverarbeitung hier hinzufügen, falls benötigt
+                        }
+                        $currentKey = $key;
+                        // Spezielle Behandlung für die DESCRIPTION
+                        if ('DESCRIPTION' == $key) {
+                            $value = $this->formatDescription($value);
+                        }
+                        $event[$key] = $value;
                     }
-                    $currentKey = $key;
-                    // Spezielle Behandlung für die DESCRIPTION
-                    if ($key == 'DESCRIPTION') {
-                        $value = $this->formatDescription($value);
-                    }
-                    $event[$key] = $value;
                 }
             }
         }
+        return $events;
     }
-    return $events;
-}
 
-private function formatDescription($description)
-{
-    // Ersetzt \n durch echte Zeilenumbrüche und behandelt andere spezielle Fälle
-    $description = str_replace("\\n", "\n", $description);
-    $description = str_replace("\\n\\n", "\n", $description);
-    // Hier können weitere Anpassungen vorgenommen werden, z.B. das Entfernen oder Ersetzen von speziellen Zeichen
-    return $description;
+    private function formatDescription($description)
+    {
+        // Ersetzt \n durch echte Zeilenumbrüche und behandelt andere spezielle Fälle
+        $description = str_replace('\\n', "\n", $description);
+        $description = str_replace('\\n\\n', "\n", $description);
+        // Hier können weitere Anpassungen vorgenommen werden, z.B. das Entfernen oder Ersetzen von speziellen Zeichen
+        return $description;
+    }
 }
-}   

--- a/lib/Stream/VimeoPro.php
+++ b/lib/Stream/VimeoPro.php
@@ -11,39 +11,41 @@
 
 namespace FriendsOfRedaxo\Feeds\Stream;
 
+use DateTime;
 use FriendsOfRedaxo\Feeds\Item;
+use rex_i18n;
 use Vimeo\Vimeo;
 
 class VimeoPro extends AbstractStream
 {
     public function getTypeName()
     {
-        return \rex_i18n::msg('feeds_vimeo_pro_user');
+        return rex_i18n::msg('feeds_vimeo_pro_user');
     }
 
     public function getTypeParams()
     {
         return [
             [
-                'label' => \rex_i18n::msg('feeds_vimeo_user_id'),
+                'label' => rex_i18n::msg('feeds_vimeo_user_id'),
                 'name' => 'client_id',
                 'type' => 'string',
             ],
             [
-                'label' => \rex_i18n::msg('feeds_vimeo_access_token'),
+                'label' => rex_i18n::msg('feeds_vimeo_access_token'),
                 'name' => 'access_token',
                 'type' => 'string',
             ],
             [
-                'label' => \rex_i18n::msg('feeds_vimeo_client_secret'),
+                'label' => rex_i18n::msg('feeds_vimeo_client_secret'),
                 'name' => 'client_secret',
                 'type' => 'string',
             ],
             [
-                'label' => \rex_i18n::msg('feeds_vimeo_view'),
+                'label' => rex_i18n::msg('feeds_vimeo_view'),
                 'name' => 'view',
                 'type' => 'select',
-                'options' => ['' => \rex_i18n::msg('feeds_vimeo_all'), 'public' => \rex_i18n::msg('feeds_vimeo_public')],
+                'options' => ['' => rex_i18n::msg('feeds_vimeo_all'), 'public' => rex_i18n::msg('feeds_vimeo_public')],
                 'default' => 'public',
             ],
         ];
@@ -59,7 +61,7 @@ class VimeoPro extends AbstractStream
             $videos = $vimeo->request('/me/videos?per_page=100');
             // $videos = $videos['body'];
             $videos_data = $videos['body']['data'];
-            while ($videos['body']['paging']['next'] != "") {
+            while ('' != $videos['body']['paging']['next']) {
                 $videos = $vimeo->request($videos['body']['paging']['next']);
                 $videos_data = array_merge($videos_data, $videos['body']['data']);
             }
@@ -69,12 +71,12 @@ class VimeoPro extends AbstractStream
 
         foreach ($videos as $video) {
             $uri = $video['uri'];
-            $uri = str_replace("/videos/", "", $uri);
+            $uri = str_replace('/videos/', '', $uri);
             $item = new Item($this->streamId, $uri);
 
-            if ($this->typeParams['view'] === 'public') {
+            if ('public' === $this->typeParams['view']) {
                 // only Videos with View-Right
-                if ($video['privacy']['view'] === 'anybody') {
+                if ('anybody' === $video['privacy']['view']) {
                 } else {
                     continue;
                 }
@@ -89,7 +91,7 @@ class VimeoPro extends AbstractStream
             $item->setMedia($video['pictures']['base_link']);
             $item->setDate(new DateTime($video['created_time']));
 
-            //$item->setAuthor($video->snippet->channelTitle);
+            // $item->setAuthor($video->snippet->channelTitle);
             $item->setRaw($video);
             $this->updateCount($item);
             $item->save();
@@ -97,14 +99,17 @@ class VimeoPro extends AbstractStream
 
         self::registerExtensionPoint($this->streamId);
     }
+
     protected function getVimeoClientID()
     {
         return $this->typeParams['client_id'];
     }
+
     protected function getVimeoAccessToken()
     {
         return $this->typeParams['access_token'];
     }
+
     protected function getVimeoClientSecret()
     {
         return $this->typeParams['client_secret'];

--- a/lib/Stream/YoutubeChannel.php
+++ b/lib/Stream/YoutubeChannel.php
@@ -11,32 +11,35 @@
 
 namespace FriendsOfRedaxo\Feeds\Stream;
 
+use Exception;
 use Madcoda\Youtube\Youtube;
+use rex_i18n;
+use rex_view;
 
 class YoutubeChannel extends YoutubePlaylist
 {
     public function getTypeName()
     {
-        return \rex_i18n::msg('feeds_youtube_channel');
+        return rex_i18n::msg('feeds_youtube_channel');
     }
 
     public function getTypeParams()
     {
         return [
             [
-                'label' => \rex_i18n::msg('feeds_youtube_channel_id'),
+                'label' => rex_i18n::msg('feeds_youtube_channel_id'),
                 'name' => 'channel_id',
                 'type' => 'string',
-                'notice' => \rex_i18n::msg('feeds_youtube_channel_id_notice')
+                'notice' => rex_i18n::msg('feeds_youtube_channel_id_notice'),
             ],
             [
-                'label' => \rex_i18n::msg('feeds_youtube_api_key'),
+                'label' => rex_i18n::msg('feeds_youtube_api_key'),
                 'name' => 'api_key',
                 'type' => 'string',
-                'notice' => \rex_i18n::msg('feeds_youtube_api_key_notice')
+                'notice' => rex_i18n::msg('feeds_youtube_api_key_notice'),
             ],
             [
-                'label' => \rex_i18n::msg('feeds_youtube_count'),
+                'label' => rex_i18n::msg('feeds_youtube_count'),
                 'name' => 'count',
                 'type' => 'select',
                 'options' => [5 => 5, 10 => 10, 15 => 15, 20 => 20, 30 => 30, 50 => 50, 75 => 75, 100 => 100],
@@ -51,11 +54,10 @@ class YoutubeChannel extends YoutubePlaylist
             $channel = $youtube->getChannelById($this->typeParams['channel_id'], ['part' => 'contentDetails']);
             dump($channel);
             return $channel->contentDetails->relatedPlaylists->uploads;
-        } catch (exception $e) {
+        } catch (Exception $e) {
             dump($e);
-            echo \rex_view::error($e->getMessage());
+            echo rex_view::error($e->getMessage());
             return false;
         }
-      
     }
 }

--- a/pages/items.php
+++ b/pages/items.php
@@ -9,13 +9,16 @@
  * file that was distributed with this source code.
  */
 
+use FriendsOfRedaxo\Feeds\Item;
+use FriendsOfRedaxo\Feeds\Stream;
+
 $func = rex_request('func', 'string');
 $id = rex_request('id', 'integer');
 
-if ($func == 'setstatus') {
+if ('setstatus' == $func) {
     $status = (rex_request('oldstatus', 'int') + 1) % 2;
     rex_sql::factory()
-        ->setTable(rex_feeds_item::table())
+        ->setTable(Item::table())
         ->setWhere('id = :id', ['id' => $id])
         ->setValue('status', $status)
         ->addGlobalUpdateFields()
@@ -31,7 +34,7 @@ if ('' == $func) {
 
     // Hole verfügbare Namespaces für den Filter
     $sql = rex_sql::factory();
-    $namespaces = $sql->getArray('SELECT DISTINCT namespace FROM ' . rex_feeds_stream::table() . ' ORDER BY namespace');
+    $namespaces = $sql->getArray('SELECT DISTINCT namespace FROM ' . Stream::table() . ' ORDER BY namespace');
 
     // Base Query
     $query = "SELECT
@@ -49,32 +52,32 @@ if ('' == $func) {
                 i.author,
                 s.type as stream_type
             FROM
-                " . rex_feeds_item::table() . " AS i
+                " . Item::table() . ' AS i
                 LEFT JOIN
-                    " . rex_feeds_stream::table() . " AS s
-                    ON  i.stream_id = s.id";
+                    ' . Stream::table() . ' AS s
+                    ON  i.stream_id = s.id';
 
     // WHERE Bedingungen
     $where = [];
     if ($search) {
-        $where[] = "(i.title LIKE '%". $search ."%' 
-                    OR i.content LIKE '%". $search ."%' 
-                    OR s.namespace LIKE '%". $search ."%' 
-                    OR i.author LIKE '%". $search ."%')";
+        $where[] = "(i.title LIKE '%" . $search . "%'
+                    OR i.content LIKE '%" . $search . "%'
+                    OR s.namespace LIKE '%" . $search . "%'
+                    OR i.author LIKE '%" . $search . "%')";
     }
     if ($namespace_filter) {
-        $where[] = "s.namespace = '". $namespace_filter ."'";
+        $where[] = "s.namespace = '" . $namespace_filter . "'";
     }
 
     // WHERE Bedingungen zusammenführen
     if (!empty($where)) {
-        $query .= " WHERE " . implode(' AND ', $where);
+        $query .= ' WHERE ' . implode(' AND ', $where);
     }
 
-    $query .= " ORDER BY i.date DESC, id DESC";
+    $query .= ' ORDER BY i.date DESC, id DESC';
 
     $list = rex_list::factory($query);
-    
+
     // Parameter an Liste übergeben
     if ($search) {
         $list->addParam('search', $search);
@@ -92,11 +95,11 @@ if ('' == $func) {
                 <div class="form-group">
                     <select class="form-control selectpicker" data-live-search="true" name="namespace_filter" onchange="this.form.submit()">
                         <option value="">' . rex_i18n::msg('feeds_all_namespaces') . '</option>';
-                        foreach ($namespaces as $n) {
-                            $searchForm .= '<option value="' . htmlspecialchars($n['namespace']) . '"' 
-                                . ($namespace_filter == $n['namespace'] ? ' selected' : '') 
-                                . '>' . htmlspecialchars($n['namespace']) . '</option>';
-                        }
+    foreach ($namespaces as $n) {
+        $searchForm .= '<option value="' . htmlspecialchars($n['namespace']) . '"'
+            . ($namespace_filter == $n['namespace'] ? ' selected' : '')
+            . '>' . htmlspecialchars($n['namespace']) . '</option>';
+    }
     $searchForm .= '</select>
                 </div>
             </div>
@@ -112,7 +115,7 @@ if ('' == $func) {
             ' . (($search || $namespace_filter) ? '
             <div class="col-sm-12">
                 <div class="alert alert-info">
-                    ' . rex_i18n::msg('feeds_search_results') . ': ' . $list->getRows() . ' 
+                    ' . rex_i18n::msg('feeds_search_results') . ': ' . $list->getRows() . '
                 </div>
             </div>' : '') . '
         </div>
@@ -126,7 +129,7 @@ if ('' == $func) {
 
     $list->addColumn('', '', 0, ['<th class="rex-table-icon">###VALUE###</th>', '<td class="rex-table-icon">###VALUE###</td>']);
     $list->setColumnParams('', ['func' => 'edit', 'id' => '###id###']);
-    $list->setColumnFormat('', 'custom', function ($params) {
+    $list->setColumnFormat('', 'custom', static function ($params) {
         /** @var rex_list $list */
         $list = $params['list'];
         $type = explode('_', $list->getValue('stream_type'));
@@ -151,7 +154,7 @@ if ('' == $func) {
     $list->removeColumn('stream_type');
 
     $list->setColumnLabel('date', $this->i18n('item_date'));
-    $list->setColumnFormat('date', 'custom', function ($params) {
+    $list->setColumnFormat('date', 'custom', static function ($params) {
         /** @var rex_list $list */
         $list = $params['list'];
         return rex_formatter::strftime($list->getValue('date'), 'datetime');
@@ -159,7 +162,7 @@ if ('' == $func) {
     $list->setColumnSortable('date');
 
     $list->setColumnLabel('namespace', $this->i18n('stream_namespace'));
-    $list->setColumnFormat('namespace', 'custom', function ($params) {
+    $list->setColumnFormat('namespace', 'custom', static function ($params) {
         /** @var rex_list $list */
         $list = $params['list'];
         $namespace = $list->getValue('namespace');
@@ -171,42 +174,42 @@ if ('' == $func) {
     $list->setColumnSortable('namespace');
 
     $list->setColumnLabel('title', $this->i18n('item_title'));
-    $list->setColumnFormat('title', 'custom', function ($params) {
+    $list->setColumnFormat('title', 'custom', static function ($params) {
         /** @var rex_list $list */
         $list = $params['list'];
         $title = $list->getValue('title');
-        if ($title === null) {
+        if (null === $title) {
             $title = '';
         }
         $title = rex_formatter::truncate($title, ['length' => 140]);
-        $title .= ($list->getValue('url') != '') ? '<br /><small><a href="' . $list->getValue('url') . '" target="_blank">' . $list->getValue('url') . '</a></small>' : '';
+        $title .= ('' != $list->getValue('url')) ? '<br /><small><a href="' . $list->getValue('url') . '" target="_blank">' . $list->getValue('url') . '</a></small>' : '';
         $title = '<div class="rex-word-break"><span class="title' . (($list->getValue('status')) ? '' : ' text-muted') . '">' . $title . '</span></div>';
         return $title;
     });
 
     $list->setColumnLabel('media_filename', $this->i18n('item_media'));
-    $list->setColumnFormat('media_filename', 'custom', function ($params) {
+    $list->setColumnFormat('media_filename', 'custom', static function ($params) {
         /** @var rex_list $list */
         $list = $params['list'];
-        $item = rex_feeds_item::get($list->getValue('id'));
-        
+        $item = Item::get($list->getValue('id'));
+
         if ($item && $item->getMediaFilename()) {
             $media_url = $item->getMediaManagerUrl('feeds_thumb');
-            return '<img class="thumbnail" src="'. $media_url.'" width="60" height="60" alt="" title="" loading="lazy">';
+            return '<img class="thumbnail" src="' . $media_url . '" width="60" height="60" alt="" title="" loading="lazy">';
         }
         return '';
     });
 
     $list->setColumnLabel('author', $this->i18n('item_author'));
     $list->setColumnSortable('author');
-    
+
     $list->setColumnLabel('status', $this->i18n('status'));
     $list->setColumnParams('status', ['func' => 'setstatus', 'oldstatus' => '###status###', 'id' => '###id###']);
     $list->setColumnLayout('status', ['<th class="rex-table-action">###VALUE###</th>', '<td class="rex-table-action">###VALUE###</td>']);
     $list->setColumnFormat('status', 'custom', function ($params) {
         /** @var rex_list $list */
         $list = $params['list'];
-        if ($list->getValue('status') == 1) {
+        if (1 == $list->getValue('status')) {
             $str = $list->getColumnLink('status', '<span class="rex-online"><i class="rex-icon rex-icon-active-true"></i> ' . $this->i18n('item_status_online') . '</span>');
         } else {
             $str = $list->getColumnLink('status', '<span class="rex-offline"><i class="rex-icon rex-icon-active-false"></i> ' . $this->i18n('item_status_offline') . '</span>');
@@ -228,13 +231,13 @@ if ('' == $func) {
     echo $searchPanel;
     echo $content;
 } else {
-    $title = $func == 'edit' ? $this->i18n('item_edit') : $this->i18n('item_add');
+    $title = 'edit' == $func ? $this->i18n('item_edit') : $this->i18n('item_add');
 
-    $form = rex_form::factory(rex_feeds_item::table(), '', 'id = ' . $id, 'post', false);
+    $form = rex_form::factory(Item::table(), '', 'id = ' . $id, 'post', false);
     $form->addParam('id', $id);
     $form->setApplyUrl(rex_url::currentBackendPage());
-    $form->setEditMode($func == 'edit');
-    $add = $func != 'edit';
+    $form->setEditMode('edit' == $func);
+    $add = 'edit' != $func;
 
     $field = $form->addHiddenField('changed_by_user', 1);
 
@@ -278,9 +281,9 @@ if ('' == $func) {
         $field = $form->addTextField('mediasource');
         $field->setLabel($this->i18n('item_mediasource'));
     }
-    
+
     if ($form->isEditMode()) {
-        $item = rex_feeds_item::get($id);
+        $item = Item::get($id);
         if ($item && $item->getMediaFilename()) {
             $form->addRawField('<div class="text-center"><img class="img-responsive" src="' . $item->getMediaManagerUrl('feeds_thumb') . '"></div>');
         }


### PR DESCRIPTION
CoPilot war eifrig und stets bemüht ...

... in vielen Dateien waren weiterhin die alten Klassen referenziert und nicht die neuen im Namespace. Das fällt zwar technisch nicht auf, da es die alten als Übergangshelfer noch gibt, aber auch hier hätte CoPilot anpassen müssen.

Außerdem waren die Referenzen auf rex-Klassen bzw. PHP-Klassen/Funktionen vielfach nicht korrekt (`\name` bzw. über `use name` erwartet). Das ist nun aufgeräumt; konsequent mit `use`, da die Dateien mit dem PHP-CS-Fixer nachbearbeitet sind.

Nicht angpasst habe ich die Dateien bzg. Watson (mangels installiertem Watson wäre das ein Blindflug gewesen) und die Datei RSS.php. Vermutlich fehlt mir der Inhalt des Vendor-Verzeichnisses. Mein Eindruck: da ist auch sonst noch was im Argen. Issue dazu folgt bei Gelegenheit.

Ebenfalls noch nicht geändert: diverse sonstige deprecated-Stellen abseits der Namespace-Thematik

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved code readability and consistency across multiple components by standardizing import statements, formatting, and string comparison styles.
  * Updated class references to use modern namespaced imports and removed legacy or fully qualified class names.
  * Enhanced code style with consistent spacing, indentation, and closure usage.
  * No changes to application logic or user-facing behavior.
* **Bug Fixes**
  * Improved error handling and description formatting in ICS stream processing for more reliable event data display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->